### PR TITLE
Density operator of Qubit

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,6 +17,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Run backend tests
+      run: |
+        export PYTHONPATH=$PWD
+        nose2 -s integration_tests test_backend
     - name: Run single hop tests
       run: |
         export PYTHONPATH=$PWD

--- a/integration_tests/test_backend.py
+++ b/integration_tests/test_backend.py
@@ -64,7 +64,7 @@ class TestBackend(unittest.TestCase):
         q2 = backend.receive_epr(
             bob.host_id, alice.host_id, q_id=q1.id)
 
-        density_operator = backend.give_density_operator(q1)
+        density_operator = backend.density_operator(q1)
         expected = np.diag([0.5, 0.5])
         self.assertTrue(np.allclose(density_operator, expected))
 

--- a/integration_tests/test_single_hop.py
+++ b/integration_tests/test_single_hop.py
@@ -5,6 +5,7 @@ from qunetsim.backends import EQSNBackend
 from qunetsim.utils.constants import Constants
 import unittest
 import time
+import numpy as np
 
 Logger.DISABLED = True
 
@@ -174,6 +175,41 @@ class TestOneHop(unittest.TestCase):
         self.assertIsNotNone(q2)
         assert q1 is not None
         assert q2 is not None
+        self.assertEqual(q1.measure(), q2.measure())
+
+    # @unittest.skip('')
+    def test_density_operator(self):
+        global hosts
+
+        q_id = hosts['alice'].send_epr(hosts['bob'].host_id)
+        q1 = hosts['alice'].get_epr(hosts['bob'].host_id, q_id)
+        i = 0
+        while q1 is None and i < TestOneHop.MAX_WAIT:
+            q1 = hosts['alice'].get_epr(hosts['bob'].host_id, q_id)
+            i += 1
+            time.sleep(1)
+
+        self.assertIsNotNone(q1)
+        i = 0
+        q2 = hosts['bob'].get_epr(hosts['alice'].host_id, q_id)
+        while q2 is None and i < TestOneHop.MAX_WAIT:
+            q2 = hosts['bob'].get_epr(hosts['alice'].host_id, q_id)
+            i += 1
+            time.sleep(1)
+
+        self.assertIsNotNone(q2)
+        assert q1 is not None
+        assert q2 is not None
+
+        # Density operator test
+        density_operator1 = q1.density_operator()
+        density_operator2 = q2.density_operator()
+        expected_density_operator = np.diag([0.5, 0.5])
+
+        self.assertTrue(np.allclose(density_operator1, expected_density_operator))
+        self.assertTrue(np.allclose(density_operator2, expected_density_operator))
+
+        # Check that the statevector has not changed
         self.assertEqual(q1.measure(), q2.measure())
 
     # @unittest.skip('')

--- a/qunetsim/backends/__init__.py
+++ b/qunetsim/backends/__init__.py
@@ -1,3 +1,4 @@
 from .eqsn_backend import EQSNBackend
+from .cqc_backend import CQCBackend
 from .rw_lock import RWLock
 from .safe_dict import SafeDict

--- a/qunetsim/backends/backend.py
+++ b/qunetsim/backends/backend.py
@@ -230,6 +230,19 @@ class Backend(object):
         raise (EnvironmentError("This is only an interface, not \
                         an actual implementation!"))
 
+    def custom_controlled_two_qubit_gate(self, qubit, target_1, target_2, gate):
+        """
+        Applies a custom gate to the target qubit, controlled by the qubit.
+
+        Args:
+            qubit (Qubit): Qubit to control the gate.
+            target_1 (Qubit): Qubit on which the gate is applied.
+            target_2 (Qubit): Qubit on which the gate is applied.
+            gate (nd.array): 4x4 array for the gate applied to target.
+        """
+        raise (EnvironmentError("This is only an interface, not \
+                        an actual implementation!"))
+
     def custom_two_qubit_gate(self, qubit1, qubit2, gate):
         """
         Applies a custom two qubit gate to qubit1 \\otimes qubit2.

--- a/qunetsim/backends/backend.py
+++ b/qunetsim/backends/backend.py
@@ -255,6 +255,20 @@ class Backend(object):
         raise (EnvironmentError("This is only an interface, not \
                         an actual implementation!"))
 
+    def give_density_operator(self, qubit):
+        """
+        Returns the density operator of this qubit. If the qubit is entangled,
+        the density operator will be in a mixed state.
+
+        Args:
+            qubit (Qubit): Qubit of the density operator.
+
+        Returns:
+            np.ndarray: The density operator of the qubit.
+        """
+        raise (EnvironmentError("This is only an interface, not \
+                        an actual implementation!"))
+
     def measure(self, qubit, non_destructive):
         """
         Perform a measurement on a qubit.

--- a/qunetsim/backends/backend.py
+++ b/qunetsim/backends/backend.py
@@ -255,7 +255,7 @@ class Backend(object):
         raise (EnvironmentError("This is only an interface, not \
                         an actual implementation!"))
 
-    def give_density_operator(self, qubit):
+    def density_operator(self, qubit):
         """
         Returns the density operator of this qubit. If the qubit is entangled,
         the density operator will be in a mixed state.

--- a/qunetsim/backends/cqc_backend.py
+++ b/qunetsim/backends/cqc_backend.py
@@ -375,6 +375,19 @@ class CQCBackend(object):
         """
         raise (EnvironmentError("Not implemented for this backend!"))
 
+    def give_density_operator(self, qubit):
+        """
+        Returns the density operator of this qubit. If the qubit is entangled,
+        the density operator will be in a mixed state.
+
+        Args:
+            qubit (Qubit): Qubit of the density operator.
+
+        Returns:
+            np.ndarray: The density operator of the qubit.
+        """
+        raise (EnvironmentError("Not implemented for this backend!"))
+
     def measure(self, qubit, non_destructive):
         """
         Perform a measurement on a qubit.

--- a/qunetsim/backends/cqc_backend.py
+++ b/qunetsim/backends/cqc_backend.py
@@ -375,7 +375,7 @@ class CQCBackend(object):
         """
         raise (EnvironmentError("Not implemented for this backend!"))
 
-    def give_density_operator(self, qubit):
+    def density_operator(self, qubit):
         """
         Returns the density operator of this qubit. If the qubit is entangled,
         the density operator will be in a mixed state.

--- a/qunetsim/backends/eqsn_backend.py
+++ b/qunetsim/backends/eqsn_backend.py
@@ -9,6 +9,7 @@ from queue import Queue
 # From O'Reilly Python Cookbook by David Ascher, Alex Martelli
 # with some smaller adaptions
 class RWLock:
+
     def __init__(self):
         self._read_ready = threading.Condition(threading.RLock())
         self._num_reader = 0
@@ -51,6 +52,7 @@ class RWLock:
 
 
 class SafeDict(object):
+
     def __init__(self):
         self.lock = RWLock()
         self.dict = {}
@@ -413,10 +415,10 @@ class EQSNBackend(object):
         density_operator = np.outer(statevector, statevector)
         before = 2**index
         if before > 0:
-            other = 2**(len(qubits)-index)
+            other = 2**(len(qubits) - index)
             density_operator = density_operator.reshape([before, other, before, other])
             density_operator = np.trace(density_operator, axis1=0, axis2=2)
-        after = 2**(len(qubits)-index-1)
+        after = 2**(len(qubits) - index - 1)
         if after > 0:
             density_operator = density_operator.reshape([2, after, 2, after])
             density_operator = np.trace(density_operator, axis1=1, axis2=3)

--- a/qunetsim/backends/eqsn_backend.py
+++ b/qunetsim/backends/eqsn_backend.py
@@ -397,7 +397,7 @@ class EQSNBackend(object):
         """
         self.eqsn.custom_two_qubit_gate(qubit1.qubit, qubit2.qubit, gate)
 
-    def give_density_operator(self, qubit):
+    def density_operator(self, qubit):
         """
         Returns the density operator of this qubit. If the qubit is entangled,
         the density operator will be in a mixed state.

--- a/qunetsim/backends/eqsn_backend.py
+++ b/qunetsim/backends/eqsn_backend.py
@@ -396,6 +396,20 @@ class EQSNBackend(object):
         """
         self.eqsn.custom_two_qubit_gate(qubit1.qubit, qubit2.qubit, gate)
 
+    def give_density_operator(self, qubit):
+        """
+        Returns the density operator of this qubit. If the qubit is entangled,
+        the density operator will be in a mixed state.
+
+        Args:
+            qubit (Qubit): Qubit of the density operator.
+
+        Returns:
+            np.ndarray: The density operator of the qubit.
+        """
+        raise (EnvironmentError("This is only an interface, not \
+                        an actual implementation!"))
+
     def measure(self, qubit, non_destructive):
         """
         Perform a measurement on a qubit.

--- a/qunetsim/backends/eqsn_backend.py
+++ b/qunetsim/backends/eqsn_backend.py
@@ -2,6 +2,7 @@ from eqsn import EQSN
 import uuid
 from qunetsim.objects.qubit import Qubit
 import threading
+import numpy as np
 from queue import Queue
 
 
@@ -407,8 +408,19 @@ class EQSNBackend(object):
         Returns:
             np.ndarray: The density operator of the qubit.
         """
-        raise (EnvironmentError("This is only an interface, not \
-                        an actual implementation!"))
+        qubits, statevector = self.eqsn.give_statevector_for(qubit.qubit)
+        index = qubits.index(qubit.qubit)
+        density_operator = np.outer(statevector, statevector)
+        before = 2**index
+        if before > 0:
+            other = 2**(len(qubits)-index)
+            density_operator = density_operator.reshape([before, other, before, other])
+            density_operator = np.trace(density_operator, axis1=0, axis2=2)
+        after = 2**(len(qubits)-index-1)
+        if after > 0:
+            density_operator = density_operator.reshape([2, after, 2, after])
+            density_operator = np.trace(density_operator, axis1=1, axis2=3)
+        return density_operator
 
     def measure(self, qubit, non_destructive):
         """

--- a/qunetsim/backends/projectq_backend.py
+++ b/qunetsim/backends/projectq_backend.py
@@ -324,7 +324,7 @@ class ProjectQBackend(object):
         """
         raise (EnvironmentError("Not implemented for this backend!"))
 
-    def give_density_operator(self, qubit):
+    def density_operator(self, qubit):
         """
         Returns the density operator of this qubit. If the qubit is entangled,
         the density operator will be in a mixed state.

--- a/qunetsim/backends/projectq_backend.py
+++ b/qunetsim/backends/projectq_backend.py
@@ -324,6 +324,19 @@ class ProjectQBackend(object):
         """
         raise (EnvironmentError("Not implemented for this backend!"))
 
+    def give_density_operator(self, qubit):
+        """
+        Returns the density operator of this qubit. If the qubit is entangled,
+        the density operator will be in a mixed state.
+
+        Args:
+            qubit (Qubit): Qubit of the density operator.
+
+        Returns:
+            np.ndarray: The density operator of the qubit.
+        """
+        raise (EnvironmentError("Not implemented for this backend!"))
+
     def measure(self, qubit, non_destructive):
         """
         Perform a measurement on a qubit.

--- a/qunetsim/objects/qubit.py
+++ b/qunetsim/objects/qubit.py
@@ -284,7 +284,7 @@ class Qubit(object):
         Returns:
             np.ndarray: The density operator of the qubit.
         """
-        self._host.backend.density_operator(self)
+        return self._host.backend.density_operator(self)
 
     def measure(self, non_destructive=False):
         """

--- a/qunetsim/objects/qubit.py
+++ b/qunetsim/objects/qubit.py
@@ -276,6 +276,16 @@ class Qubit(object):
 
         self._host.backend.custom_two_qubit_gate(self, other_qubit, gate)
 
+    def density_operator(self):
+        """
+        Returns the density operator of this qubit. If the qubit is entangled,
+        the density operator will be in a mixed state.
+
+        Returns:
+            np.ndarray: The density operator of the qubit.
+        """
+        self._host.backend.density_operator(self)
+
     def measure(self, non_destructive=False):
         """
         Measures the state of a qubit.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ matplotlib==3.1.2
 networkx==2.4
 nose2==0.9.1
 numpy==1.18.1
-projectq==0.4.2
 cqc==3.2.2
 simulaqron==3.0.15
 eqsn==0.0.8


### PR DESCRIPTION
* Added the functionality to get the density operator of a qubit. This currently only works with the EQSN backend.
* Added the backend tests to the github workflow.
* New backend test for density operator and test in single hop.

Also: 
I had to remove projectQ from the requirements, since it throws an error with the new pip version. This does not affect any unittests etc., and the package can still be installed manually. I think we can add the package to the requirements again if they fixed this pip issue.