### PR TITLE
dev_requirements updated

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -13,7 +13,7 @@ chardet==3.0.4
 Click==7.0
 constantly==15.1.0
 coverage==4.5.4
-cqc==3.1.1
+cqc==3.2.2
 cryptography==3.3.2
 cycler==0.10.0
 daemons==1.3.1
@@ -59,7 +59,7 @@ pexpect==4.7.0
 pickleshare==0.7.5
 pkginfo==1.5.0.1
 pluggy==0.13.1
-projectq==0.4.2
+projectq>=0.4.2
 prometheus-client==0.7.1
 prompt-toolkit==3.0.2
 ptyprocess==0.6.0
@@ -79,10 +79,10 @@ pyzmq==18.1.1
 readme-renderer==26.0
 requests==2.22.0
 requests-toolbelt==0.9.1
-scipy==1.4.1
+scipy==1.5.4
 SecretStorage==3.1.2
 Send2Trash==1.5.0
-simulaqron==3.0.12
+simulaqron==3.0.15
 six==1.14.0
 snowballstemmer==1.9.1
 Sphinx==3.1.1
@@ -104,4 +104,4 @@ urllib3==1.25.3
 wcwidth==0.1.7
 webencodings==0.5.1
 zipp==0.6.0
-zope.interface==4.7.1
+zope.interface>=4.7.1


### PR DESCRIPTION
Installing the requirements in dev_requirements.txt failed because several of the requirements are older versions than those in requirements.txt. I updated those and changed "==" to ">=" for modules that still failed until those changes were made.