### PR TITLE
Remove Project Q warning from install [unitaryHACK]

### DIFF
--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -67,6 +67,12 @@ Writing your own Backend
 Instead of using a provided backend, it is also possible to write an own backend. In this section,
 we describe how the interfacing to a backend works.
 
+.. note::
+    We include ProjectQ as a development package which may not install properly without a C++ compiler. See ProjectQ
+    documentation for how to install ProjectQ with just the Python version. The issue can be resolved in
+    most cases by running :code:`pip install projectq --global-option=--without-cppsimulator` and then installing the
+    dev requirements again, but this will only install the ProjectQ Python simulator, and not the C version.
+
 The interface is described in the file **backends.backend**.
 The interface to the backend is a class. There can be multiple instances of this
 class at once, and it has to be thread safe. This class also has to store all information

--- a/docs/source/install/linux_mac.rst
+++ b/docs/source/install/linux_mac.rst
@@ -11,16 +11,6 @@
     3) :code:`pip install --upgrade pip`
     4) :code:`pip install -r ./QuNetSim/requirements.txt`
 
-
-.. note::
-    We include ProjectQ as a standard package which may not install properly without a C++ compiler. See ProjectQ
-    documentation for how to install ProjectQ with just the Python version. Alternatively, you can edit the
-    :code:`requirements.txt` file and remove the ProjectQ requirement since it is optional. The issue can be resolved in
-    most cases by running :code:`pip install projectq --global-option=--without-cppsimulator` and then running step 4
-    above again, but this will only install the ProjectQ Python simulator, and not the C version.
-
-
-
 4) To set the correct Python path run:
 
     1) :code:`export PYTHONPATH=$PYTHONPATH:$PWD/QuNetSim/`

--- a/docs/source/install/linux_mac.rst
+++ b/docs/source/install/linux_mac.rst
@@ -11,6 +11,16 @@
     3) :code:`pip install --upgrade pip`
     4) :code:`pip install -r ./QuNetSim/requirements.txt`
 
+
+.. note::
+    We include ProjectQ as a standard package which may not install properly without a C++ compiler. See ProjectQ
+    documentation for how to install ProjectQ with just the Python version. Alternatively, you can edit the
+    :code:`requirements.txt` file and remove the ProjectQ requirement since it is optional. The issue can be resolved in
+    most cases by running :code:`pip install projectq --global-option=--without-cppsimulator` and then running step 4
+    above again, but this will only install the ProjectQ Python simulator, and not the C version.
+
+
+
 4) To set the correct Python path run:
 
     1) :code:`export PYTHONPATH=$PYTHONPATH:$PWD/QuNetSim/`

--- a/docs/source/install/windows.rst
+++ b/docs/source/install/windows.rst
@@ -11,15 +11,6 @@
     #) :code:`python -m pip install --upgrade pip`
     #) :code:`python -m pip install -r .\QuNetSim\requirements.txt`
 
-
-.. note::
-    We include ProjectQ as a standard package which may not install properly without a C++ compiler. See ProjectQ
-    documentation for how to install ProjectQ with just the Python version. Alternatively, you can edit the
-    :code:`requirements.txt` file and remove the ProjectQ requirement since it is optional. The issue can be resolved in
-    most cases by running :code:`pip install projectq --global-option=--without-cppsimulator` and then running step 4
-    above again, but this will only install the ProjectQ Python simulator, and not the C version.
-
-
 4) To set the correct Python path we need to set the :code:`PYTHONPATH` system variable:
 
     #) Open System Properties -> Advanced

--- a/docs/source/install/windows.rst
+++ b/docs/source/install/windows.rst
@@ -11,6 +11,15 @@
     #) :code:`python -m pip install --upgrade pip`
     #) :code:`python -m pip install -r .\QuNetSim\requirements.txt`
 
+
+.. note::
+    We include ProjectQ as a standard package which may not install properly without a C++ compiler. See ProjectQ
+    documentation for how to install ProjectQ with just the Python version. Alternatively, you can edit the
+    :code:`requirements.txt` file and remove the ProjectQ requirement since it is optional. The issue can be resolved in
+    most cases by running :code:`pip install projectq --global-option=--without-cppsimulator` and then running step 4
+    above again, but this will only install the ProjectQ Python simulator, and not the C version.
+
+
 4) To set the correct Python path we need to set the :code:`PYTHONPATH` system variable:
 
     #) Open System Properties -> Advanced


### PR DESCRIPTION
Project Q is not listed in requirements; it is listed under dev_requirements. Therefore, I removed the warning in the install documents.

I only made edits to the source documents and not the documentation itself, because I could not figure out how you are implementing sphinx.