### PR TITLE
QuNetSim updates and other various improvements

### DIFF
--- a/docs/source/components/channel_models.rst
+++ b/docs/source/components/channel_models.rst
@@ -1,0 +1,21 @@
+Channel Models
+=======
+
+Channels act as communication modes between the hosts in a network. Each host defines it's quantum and classical 
+connections with the other hosts in the network. QuNetSim introduces various channel models to mimic the real-world 
+quantum connections between the hosts.
+The default channel model for quantum connections is fibre.
+
+QuNetSim implements the following channel models for quantum connections:
+
+* :code:`BitFlip(probability)`
+    * Flips the single-qubit (Pauli X) passing through the channel with certain probability
+* :code:`PhaseFlip(probability)`
+    * Flips the phase of the single-qubit (Pauli Z) passing through the channel with certain probability 
+* :code:`BinaryErasure(probability)`
+    * Erases the single-qubit passing through the channel with certain probability
+* :code:`Fibre(length, alpha)`
+    * Erases the single-qubit passing through the channel with certain probability determined from the length and absorption coefficient (alpha) of the channel
+
+.. automodule:: qunetsim.components.objects.connections.channel_models
+   :members:

--- a/docs/source/components/network.rst
+++ b/docs/source/components/network.rst
@@ -28,12 +28,6 @@ The most commonly used methods for Network are:
     * If the network should recalculate the route at each node in the route (set to True) or just once at the beginning (set to False)
 * :code:`(property) delay(float)`
     * the amount of delay the network should have. The network has the ability to throttle packet transmissions which is sometimes neccessary for different types of qubit / network backends.
-* :code:`(property) packet_drop_rate(float)`
-    * The probability that a packet is dropped on transmission in the network
-* :code:`(property) x_error_rate(float)`
-    * The probability that a qubit has an :math:`X` gate applied to in at each host in the route
-* :code:`(property) z_error_rate(float)`
-    * The probability that a qubit has an :math:`Z` gate applied to in at each host in the route
 * :code:`draw_classical_network`
     * Generate a depiction of the classical network 
 * :code:`draw_quantum_network`

--- a/docs/source/examples/QKD_BB84.rst
+++ b/docs/source/examples/QKD_BB84.rst
@@ -94,10 +94,10 @@ the same bit again, until the transmission works.
                 if base == 1:
                     q_bit.H()
 
-                # Send Qubit to Bob
+                # Send Qubit to Eve
                 alice.send_qubit(receiver, q_bit, await_ack=True)
 
-                # Get measured basis of Bob
+                # Get measured basis of Eve
                 message = alice.get_next_classical_message(receiver, msg_buff, sequence_nr)
 
                 # Compare to send basis, if same, answer with 0 and set ack True and go to next bit,
@@ -130,7 +130,7 @@ the same bit again, until the transmission works.
                 q_bit.H()
             bit = q_bit.measure()
 
-            # Send Alice the base in which Bob has measured
+            # Send Alice the base in which Eve has measured
             eve.send_classical(sender, "%d:%d" % (sequence_nr, measurement_base), await_ack=True)
 
             # get the return message from Alice, to know if the bases have matched
@@ -211,7 +211,7 @@ We can now concatenate the two actions of Alice and Eve and let them each run in
         eve_key = eve_qkd(eve, msg_buff, key_size, host_alice.host_id)
         eve_receive_message(eve, msg_buff, eve_key, host_alice.host_id)
 
-    # Run Bob and Alice
+    # Run Eve and Alice
 
     t1 = host_alice.run_protocol(alice_func, ())
     t2 = host_eve.run_protocol(eve_func, ())
@@ -275,10 +275,10 @@ The full example is below:
                 if base == 1:
                     q_bit.H()
 
-                # Send Qubit to Bob
+                # Send Qubit to Eve
                 alice.send_qubit(receiver, q_bit, await_ack=True)
 
-                # Get measured basis of Bob
+                # Get measured basis of Eve
                 message = alice.get_next_classical_message(receiver, msg_buff, sequence_nr)
 
                 # Compare to send basis, if same, answer with 0 and set ack True and go to next bit,
@@ -312,7 +312,7 @@ The full example is below:
                 q_bit.H()
             bit = q_bit.measure()
 
-            # Send Alice the base in which Bob has measured
+            # Send Alice the base in which Eve has measured
             eve.send_classical(sender, "%d:%d" % (sequence_nr, measurement_base), await_ack=True)
 
             # get the return message from Alice, to know if the bases have matched
@@ -404,7 +404,7 @@ The full example is below:
             eve_key = eve_qkd(eve, msg_buff, key_size, host_alice.host_id)
             eve_receive_message(eve, msg_buff, eve_key, host_alice.host_id)
 
-        # Run Bob and Alice
+        # Run Eve and Alice
 
         t1 = host_alice.run_protocol(alice_func, ())
         t2 = host_eve.run_protocol(eve_func, ())

--- a/docs/source/examples/entanglement_routing.rst
+++ b/docs/source/examples/entanglement_routing.rst
@@ -139,6 +139,7 @@ The full example is below.
     from qunetsim.objects import Logger
     import networkx
     import time
+    import random
 
 
     def generate_entanglement(host):

--- a/docs/source/examples/packet_sniffing.rst
+++ b/docs/source/examples/packet_sniffing.rst
@@ -85,7 +85,7 @@ We set these protocols to the hosts via the following code:
     :linenos:
 
     host_bob.q_relay_sniffing = True
-    host_bob.q_relay_sniffing_fn = eve_sniffing_quantum
+    host_bob.q_relay_sniffing_fn = bob_sniffing_quantum
 
     host_bob.c_relay_sniffing = True
     host_bob.c_relay_sniffing_fn = bob_sniffing_classical
@@ -196,7 +196,7 @@ The full example is below.
         network.add_host(host_eve)
 
         host_bob.q_relay_sniffing = True
-        host_bob.q_relay_sniffing_fn = eve_sniffing_quantum
+        host_bob.q_relay_sniffing_fn = bob_sniffing_quantum
 
         host_bob.c_relay_sniffing = True
         host_bob.c_relay_sniffing_fn = bob_sniffing_classical

--- a/docs/source/examples/quantum_money.rst
+++ b/docs/source/examples/quantum_money.rst
@@ -189,7 +189,6 @@ The full example is below:
     from qunetsim.objects import Logger
     from qunetsim.objects import Qubit
     from random import randint, random
-    from qunetsim.backends import ProjectQBackend
 
     Logger.DISABLED = True
 

--- a/docs/source/examples/send_epr.rst
+++ b/docs/source/examples/send_epr.rst
@@ -1,7 +1,7 @@
 Send EPR Pairs
 --------------
 
-In this example, we'll see how to generate a network with 4 nodes as in the figure below.
+In this example, we'll see how to generate a network with 3 nodes connected in a linear fashion.
 We'll then send an EPR pair from one end of the link to the other. The example shows
 how to build a network and a simple application.
 

--- a/docs/source/examples/send_w.rst
+++ b/docs/source/examples/send_w.rst
@@ -87,7 +87,7 @@ then the system density matrix is printed and a measurement on each participant 
     q4 = host_dean.get_w('Alice', q_id1, wait=10)
 
     print("System density matrix:")
-    print(q1._qubit[0].data)
+    print(q1.density_operator())
 
     m1 = q1.measure()
     m2 = q2.measure()
@@ -154,7 +154,7 @@ The full example is below:
         q4 = host_dean.get_w('Alice', q_id1, wait=10)
 
         print("System density matrix:")
-        print(q1._qubit[0].data)
+        print(q1.density_operator())
 
         m1 = q1.measure()
         m2 = q2.measure()

--- a/integration_tests/test_backend.py
+++ b/integration_tests/test_backend.py
@@ -25,6 +25,14 @@ class TestBackend(unittest.TestCase):
     def tearDownClass(cls):
         pass
 
+    def test_qubit_initialization(self):
+        backend = EQSNBackend()
+        host_alice = Host('Alice', backend)
+        qubit_initialized = Qubit(host_alice, theta=np.pi/2, phi=np.pi/2)
+
+        self.assertAlmostEqual(host_alice.backend.eqsn.give_statevector_for(qubit_initialized.qubit)[1][0], 0.5-0.5j)
+        self.assertAlmostEqual(host_alice.backend.eqsn.give_statevector_for(qubit_initialized.qubit)[1][1], 0.5+0.5j)
+
     # @unittest.skip('')
     def test_epr_generation(self):
         for b in TestBackend.backends:

--- a/qunetsim/objects/connections/channel_models/__init__.py
+++ b/qunetsim/objects/connections/channel_models/__init__.py
@@ -1,2 +1,6 @@
 from .fibre import Fibre
 from .binary_erasure import BinaryErasure
+from .bit_flip import BitFlip
+from .phase_flip import PhaseFlip
+from .channel_model import ChannelModel
+from .classical_model import ClassicalModel

--- a/qunetsim/objects/connections/channel_models/binary_erasure.py
+++ b/qunetsim/objects/connections/channel_models/binary_erasure.py
@@ -1,12 +1,13 @@
 import random
+from qunetsim.objects.connections.channel_models.channel_model import ChannelModel
 
-
-class BinaryErasure(object):
+class BinaryErasure(ChannelModel):
     """
     The model for a binary erasure connection.
     """
 
     def __init__(self, probability=0.0):
+        super().__init__(ChannelModel.QUANTUM)
         if not isinstance(probability, int) and not isinstance(probability, float):
             raise ValueError("Erasure probability must be float or int")
         elif probability < 0 or probability > 1:

--- a/qunetsim/objects/connections/channel_models/bit_flip.py
+++ b/qunetsim/objects/connections/channel_models/bit_flip.py
@@ -1,0 +1,58 @@
+import random
+from qunetsim.objects.connections.channel_models.channel_model import ChannelModel
+
+class BitFlip(ChannelModel):
+    """
+    The model for a bit flip quantum connection.
+    """
+
+    def __init__(self, probability=0.0):
+        super().__init__(ChannelModel.QUANTUM)
+        if not isinstance(probability, int) and not isinstance(probability, float):
+            raise ValueError("Bit Flip probability must be float or int")
+        elif probability < 0 or probability > 1:
+            raise ValueError("Bit Flip probability must lie in the interval [0, 1]")
+        else:
+            self._p = probability
+
+    @property
+    def bitflip_probability(self):
+        """
+        Probability of bit flip of qubit
+
+        Returns
+            (float) : Probability that a qubit is flipped during transmission
+        """
+        return self._p
+
+    @bitflip_probability.setter
+    def bitflip_probability(self, probability):
+        """
+        Set the bit flip probability of the channel
+
+        Args
+            probability (float) : Probability that a qubit is flipped during transmission
+        """
+        if not isinstance(probability, int) and not isinstance(probability, float):
+            raise ValueError("Bit flip probability must be float or int")
+        elif probability < 0 or probability > 1:
+            raise ValueError("Bit flip probability must lie in the interval [0, 1]")
+        else:
+            self._p = probability
+
+    def qubit_func(self, qubit):
+        """
+        Function to modify the qubit based on channel properties
+        In this case - Returns flipped qubit, otherwise returns the original qubit
+        Required in all channel models
+
+        Returns
+            (object) : Modified qubit
+        """
+        if random.random() > (1.0 - self.bitflip_probability):
+            if qubit is not None:
+                qubit.X()
+            return qubit
+        else:
+            return qubit
+        

--- a/qunetsim/objects/connections/channel_models/channel_model.py
+++ b/qunetsim/objects/connections/channel_models/channel_model.py
@@ -1,0 +1,8 @@
+class ChannelModel(object):
+    """
+    A parent class for all the channel models
+    """
+    QUANTUM = "Quantum"
+    CLASSICAL = "Classical"
+    def __init__(self, type) -> None:
+        self.type = type

--- a/qunetsim/objects/connections/channel_models/classical_model.py
+++ b/qunetsim/objects/connections/channel_models/classical_model.py
@@ -1,9 +1,12 @@
-class ClassicalModel(object):
+from qunetsim.objects.connections.channel_models.channel_model import ChannelModel
+
+class ClassicalModel(ChannelModel):
     """
     The model for a classical erasure channel.
     """
 
     def __init__(self):
+        super().__init__(ChannelModel.CLASSICAL)
         self._length = 0
         self._transmission_p = 1.0
 

--- a/qunetsim/objects/connections/channel_models/fibre.py
+++ b/qunetsim/objects/connections/channel_models/fibre.py
@@ -1,12 +1,13 @@
 import random
+from qunetsim.objects.connections.channel_models.channel_model import ChannelModel
 
-
-class Fibre(object):
+class Fibre(ChannelModel):
     """
     The model for a fibre optic connection.
     """
 
     def __init__(self, length=0.0, alpha=0.0):
+        super().__init__(ChannelModel.QUANTUM)
         if not isinstance(length, int) and not isinstance(length, float):
             raise ValueError("Length must be float or int")
         elif length < 0:

--- a/qunetsim/objects/connections/channel_models/phase_flip.py
+++ b/qunetsim/objects/connections/channel_models/phase_flip.py
@@ -1,0 +1,57 @@
+import random
+from qunetsim.objects.connections.channel_models.channel_model import ChannelModel
+
+class PhaseFlip(ChannelModel):
+    """
+    The model for a phase flip quantum connection.
+    """
+
+    def __init__(self, probability=0.0):
+        super().__init__(ChannelModel.QUANTUM)
+        if not isinstance(probability, int) and not isinstance(probability, float):
+            raise ValueError("Phase Flip probability must be float or int")
+        elif probability < 0 or probability > 1:
+            raise ValueError("Phase Flip probability must lie in the interval [0, 1]")
+        else:
+            self._p = probability
+
+    @property
+    def phaseflip_probability(self):
+        """
+        Probability of phase flip of qubit
+
+        Returns
+            (float) : Probability that a qubit's phase is flipped during transmission
+        """
+        return self._p
+
+    @phaseflip_probability.setter
+    def phaseflip_probability(self, probability):
+        """
+        Set the phase flip probability of the channel
+
+        Args
+            probability (float) : Probability that a qubit's phase is flipped during transmission
+        """
+        if not isinstance(probability, int) and not isinstance(probability, float):
+            raise ValueError("Phase flip probability must be float or int")
+        elif probability < 0 or probability > 1:
+            raise ValueError("Phase flip probability must lie in the interval [0, 1]")
+        else:
+            self._p = probability
+
+    def qubit_func(self, qubit):
+        """
+        Function to modify the qubit based on channel properties
+        In this case - Returns qubit with phase flipped, otherwise returns the original qubit
+        Required in all channel models
+
+        Returns
+            (object) : Modified qubit
+        """
+        if random.random() > (1.0 - self.phaseflip_probability):
+            if qubit is not None:
+                qubit.Z()
+            return qubit
+        else:
+            return qubit

--- a/qunetsim/objects/connections/classical_connection.py
+++ b/qunetsim/objects/connections/classical_connection.py
@@ -1,6 +1,7 @@
+import unittest
 from qunetsim.objects.connections.channel_models.classical_model import ClassicalModel
 from qunetsim.objects.connections.connection import Connection
-
+from .channel_models.channel_model import ChannelModel
 
 class ClassicalConnection(Connection):
     """
@@ -11,4 +12,6 @@ class ClassicalConnection(Connection):
         if model is None:
             super().__init__(sender_id, receiver_id, ClassicalModel())
         else:
+            if model.type != ChannelModel.CLASSICAL:
+                raise Exception("Classical connection should have the model type - classical")
             super().__init__(sender_id, receiver_id, model)

--- a/qunetsim/objects/daemon_thread.py
+++ b/qunetsim/objects/daemon_thread.py
@@ -4,9 +4,11 @@ import threading
 class DaemonThread(threading.Thread):
     """ A Daemon thread that runs a task until completion and then exits. """
 
-    def __init__(self, target, args=None):
-        if args is not None:
-            super().__init__(target=target, daemon=True, args=args)
+    def __init__(self, target, args=None, kwargs=None):
+        if kwargs is not None:
+            super().__init__(target=target, daemon=True, args=args, kwargs=kwargs)
+        elif args is not None:
+            super().__init__(target=target, daemon=True, args=args) 
         else:
             super().__init__(target=target, daemon=True)
         self.start()

--- a/qunetsim/objects/qubit.py
+++ b/qunetsim/objects/qubit.py
@@ -14,7 +14,7 @@ class Qubit(object):
     GHZ_QUBIT = "GHZ"
     W_QUBIT = "W"
 
-    def __init__(self, host, qubit=None, q_id=None, blocked=False):
+    def __init__(self, host, qubit=None, q_id=None, blocked=False, theta=None, phi=None):
         self._blocked = blocked
         self._host = host
         if q_id is not None:
@@ -25,6 +25,8 @@ class Qubit(object):
             self._qubit = qubit
         else:
             self._qubit = self._host.backend.create_qubit(self._host.host_id)
+        if theta is not None and phi is not None:
+            self.initialize_qubit(theta, phi)
 
     @property
     def host(self):
@@ -105,6 +107,18 @@ class Qubit(object):
             state (bool): True for blocked, False if not.
         """
         self._blocked = state
+    
+    def initialize_qubit(self, theta, phi):
+        """
+        Initializes the qubit according to the angles
+
+        Args:
+            theta (float): Rotation in radians around Y axis
+            phi (float): Rotation in radians around Z axis
+        """
+        self._host.backend.ry(self, theta)
+        self._host.backend.rz(self, phi)
+
 
     def send_to(self, receiver_id):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,7 @@
-matplotlib==3.1.2
-networkx==2.4
+matplotlib==3.7.0
+networkx<3.0
 nose2==0.9.1
-numpy==1.22.0
-cqc==3.2.2
-simulaqron==3.0.15
+numpy==1.24.1
 eqsn==0.0.8
-# qutip==4.5.2
-scipy==1.5.4
+scipy==1.10.0
 pathvalidate==2.4.1

--- a/templater.py
+++ b/templater.py
@@ -195,12 +195,14 @@ def gen_import_statements(backend_num: int) -> StringIO:
 
     imports.write("from qunetsim.components import Host, Network\n")
     imports.write("from qunetsim.objects import Message, Qubit, Logger\n")
-    imports.write("from qunetsim.backends import " +
-                  backends[backend_num]['import'] + '\n')
+    if backend_num != 1:
+        imports.write("from qunetsim.backends import " +
+                      backends[backend_num]['import'] + '\n')
     imports.write("Logger.DISABLED = True\n\n")
-    imports.write("# create the " + backends[backend_num]['name'] +
-                  " backend object\n")
-    imports.write("backend = " + backends[backend_num]['import'] + "()\n\n\n")
+    if backend_num != 1:
+        imports.write("# create the " + backends[backend_num]['name'] +
+                        " backend object\n")
+        imports.write("backend = " + backends[backend_num]['import'] + "()\n\n\n")
     imports.seek(0)
     return imports
 


### PR DESCRIPTION
…fied the templater to remove the backend choice.

Added the kwargs argument for host.run_protocol

Adding the bit_flip and phase_flip channel models

Removed the commented libraries from requirements.txt

Modified the template generation file

Adding the channel model parameter

Modified the test case for channel models and renamed channel_model file

Added the function to send n-qubits and it's unit-test

Added the method to initialize a qubit given angles theta and phi, tested only for the EQSN backend

Added the classical storage in host

Adding the channel_models documentation

Made a new function for changing the host ID for the EPR qubit

Changed the parameters for fibre channel in channel_models

Changed the alignment

Changed the alignment

Made minor changes to the examples in the docs